### PR TITLE
prove LemmaPow in util/math.dfy

### DIFF
--- a/src/dafny/util/math.dfy
+++ b/src/dafny/util/math.dfy
@@ -84,11 +84,80 @@ module MathUtils {
         }
     }
 
+    lemma mul_assoc (x : nat, y : nat, z : nat)
+    ensures x * y * z == x * (y * z)
+    {}
+
+    lemma mul_comm (x : nat, y : nat)
+    ensures x * y == y * x 
+    {}
+
     // Another simple lemma about pow.
-    lemma {:verify false} LemmaPow(n: nat, m:nat)
-    requires m > 1
-    ensures Pow(n,m) == n * Pow(n,m-1) {
-        // FIXME: prove this!
+    lemma LemmaPow (n : nat, k : nat)      
+    ensures Pow(n, k + 2) == n * n * Pow(n, k)
+    ensures Pow(n, k + 1) == n * Pow(n, k)
+    {  
+      if k == 0 {} 
+      else {                     
+        assert H0 : Pow(n,k) == n * Pow(n, k - 1) by {LemmaPow(n, k-1); }   
+        calc {
+          Pow(n, k+1); 
+        == {LemmaPow(n, k-1);}  
+          n * n * Pow(n,k-1);
+        == {mul_assoc(n,n,Pow(n,k-1));}
+          n * (n * Pow(n,k-1));
+        == {reveal H0;}
+          n * Pow(n,k);
+        }
+        var x := Pow(n,k/2);
+        assert k/2 < k;
+        assert H1 : Pow(n, k/2 + 1) == n * x by {LemmaPow(n, k/2);}   
+        if k % 2 == 0 {                              
+          assert H2 : Pow(n, k) == x * x;          
+          calc {
+            Pow(n, k + 2);           
+          == 
+            Pow(n, k/2 + 1) * Pow(n, k/2 + 1) ;
+          == {reveal H1;}
+            (n * x) * (n * x);
+          == {mul_assoc((n * x), n, x);}
+            (n * x * n) * x;
+          == {mul_assoc(n,x,n);}
+            (n * (x * n)) * x;
+          == {mul_comm(x,n);}
+            (n * (n * x)) * x;
+          == {mul_assoc(n,n,x);}
+            ((n * n) * x) * x;
+          == {mul_assoc(n * n, x, x);}
+            n * n * (x * x);          
+          == {reveal H2;}
+            n * n * Pow(n,k);
+          }
+        } else {         
+          assert H2 : Pow(n, k) == x * x * n;                  
+          calc  {
+            Pow(n, k+2);
+          == 
+            Pow(n,k/2 + 1) * Pow(n,k/2 + 1) * n;
+          == {reveal H1;}
+            (n * x) * (n * x) * n;
+          == {mul_assoc(n*x, n*x, n);}
+            ((n * x) * (n * x)) * n;
+          == {mul_comm((n*x) * (n*x) ,n);}
+            n * ((n*x) * (n*x));
+           == {mul_assoc(n, x, n*x);}
+            n * (n * (x * (n * x)));
+          == {mul_comm(n,x);}
+            n * (n * (x * (x * n)));
+          == {mul_assoc(x,x,n);}
+            n * (n * (x * x * n));
+          == {reveal H2;}
+            n * (n * Pow(n,k));  
+          == {mul_assoc(n,n,Pow(n,k));}
+            n * n * Pow(n,k);
+          }        
+        }       
+      }
     }
 
     // Calculate sequence [x^0, x^1, x^2, .. x^(n-1)].


### PR DESCRIPTION
## Overview
- Added proof for LemmaPow, which was previously unproven.
- Also added simple lemmas for multiplication (mul_assoc, mul_comm).

## Details of the Proof
- Proved that `Pow(n, k + 1) == n * Pow(n, k)` and, at the same time, `Pow(n, k + 2) == n * n * Pow(n, k)`. This facilitated the application of induction based on the distinction between even and odd cases.

## About the Multiplication Lemmas
Although `mul_assoc` and `mul_comm` can be proven automatically, assertions using them (e.g., `(n * x) * (n * x) == n * n * x * x`) couldn't be automatically proven. I have explicitly used these lemmas with the `clac` clause, but it might appear somewhat verbose. If there is a more efficient way to prove this, I would appreciate your advice. Also, I welcome your thoughts on the appropriate placement for `mul_assoc` and `mul_comm`.

## Additional Questions
- I would like to hear your opinion on whether it would be better to create a separate proposition specifically for `Pow(n, k + 1) == n * Pow(n, k)`.
- I omitted the `m > 1` precondition and represented exponentiation steps using addition. Do you see any issues with this approach?
